### PR TITLE
Add a "stop" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To start an app with Devon, you will need a config file called `devon.conf.yaml`
 ```yaml
 modes:
   development:
-    command: ["bundle", "exec", "rails", "server"]
+    start-command: ["bundle", "exec", "rails", "server"]
     dependencies:
       # These are key-value pairs, where the key is the name of
       # the dependency's git repo, and the value is the name of
@@ -73,7 +73,7 @@ modes:
       my-app: dependency
       your-app: custom-mode
   dependency:
-    command: ["dev/up.sh"]
+    start-command: ["dev/up.sh"]
     dependencies:
       my-app: dependency
       your-app: dependency

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2020 Redbubble
-
-*/
 package cmd
 
 import (
@@ -84,6 +80,12 @@ var startCmd = &cobra.Command{
 	},
 }
 
+func init() {
+	rootCmd.AddCommand(startCmd)
+
+	startCmd.PersistentFlags().StringVarP(&mode, "mode", "m", "development", "The mode to run in, e.g. 'development' or 'dependency'. Default: development")
+}
+
 func getAppName(args []string) (string, error) {
 	if len(args) > 0 {
 		return args[0], nil
@@ -103,21 +105,6 @@ func bail(err error) {
 		fmt.Printf("ERROR: %v\n", err)
 		os.Exit(1)
 	}
-}
-
-func init() {
-	rootCmd.AddCommand(startCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// startCmd.PersistentFlags().String("foo", "", "A help for foo")
-	startCmd.PersistentFlags().StringVarP(&mode, "mode", "m", "development", "The mode to run in, e.g. 'development' or 'dependency'. Default: development")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// startCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
 func currentGitRepo() (string, error) {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	// "fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redbubble/devon/domain"
+)
+
+var stopCmd = &cobra.Command{
+	Use:   "stop [application] [flags]",
+	Short: "Stop your chosen application",
+	Long: `Stop your chosen application
+
+* If <application> is set, devon will start it and its dependencies.
+* If <application> is unset, devon will attempt to figure out which application
+  it should start, based on the current working directory.
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var appName string
+		var err error
+
+		appName, err = getAppName(args)
+		bail(err)
+
+		app, err := domain.NewApp(appName, mode)
+		bail(err)
+
+		err = app.Stop()
+		bail(err)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(stopCmd)
+
+	stopCmd.PersistentFlags().StringVarP(&mode, "mode", "m", "development", "The mode to run in, e.g. 'development' or 'dependency'. Default: development")
+}

--- a/domain/app.go
+++ b/domain/app.go
@@ -27,6 +27,7 @@ type Config struct {
 type Mode struct {
 	Name         string
 	StartCommand []string `yaml:"start-command"`
+	StopCommand  []string `yaml:"stop-command"`
 	Dependencies map[string]string
 }
 
@@ -65,22 +66,55 @@ func NewApp(name string, modeName string) (App, error) {
 }
 
 func (a *App) Start() error {
-	executable, err := a.executable()
+	fmt.Println()
+	fmt.Printf("----- Starting %s -----\n", a.Name)
+
+	if len(a.Mode.StartCommand) == 0 {
+		return fmt.Errorf("Don't know how to start %s in '%s' mode, because start-command is unset.", a.Name, a.Mode.Name)
+	}
+
+	return runCommand(a.Mode.StartCommand, a.SourceDir)
+}
+
+func (a *App) Stop() error {
+	fmt.Println()
+	fmt.Printf("----- Stopping %s -----\n", a.Name)
+
+	if len(a.Mode.StopCommand) == 0 {
+		return fmt.Errorf("Don't know how to stop %s in '%s' mode, because stop-command is unset.", a.Name, a.Mode.Name)
+	}
+
+	return runCommand(a.Mode.StopCommand, a.SourceDir)
+}
+
+func runCommand(command []string, sourceDir string) error {
+
+	// In the case of tools like `make`, the executable will be on the PATH
+	// and LookPath will find it.
+	executable, err := exec.LookPath(command[0])
+
+	// If not, the executable may be a script within the repo. LookPath will
+	// only find that if we give it a complete path, including the
+	// application directory.
+	if err != nil {
+		executable, err = exec.LookPath(filepath.Join(sourceDir, command[0]))
+	}
+
+	if err != nil {
+		return err
+	}
 
 	cmd := exec.Cmd{
 		Path:   executable,
-		Args:   a.Mode.StartCommand,
-		Dir:    a.SourceDir,
+		Args:   command,
+		Dir:    sourceDir,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 	}
 
-	fmt.Println()
-	fmt.Printf("----- Starting %s -----\n", a.Name)
-
 	if viper.IsSet("verbose") {
 		fmt.Printf("Working directory: %s\n", cmd.Dir)
-		fmt.Printf("StartCommand: %v\n", cmd.Args)
+		fmt.Printf("Command: %v\n", cmd.Args)
 		fmt.Println()
 	}
 
@@ -91,27 +125,6 @@ func (a *App) Start() error {
 	}
 
 	return cmd.Wait()
-}
-
-func (a *App) executable() (string, error) {
-	command := a.Mode.StartCommand
-
-	// In the case of tools like `make`, the executable will be on the PATH
-	// and LookPath will find it.
-	executable, err := exec.LookPath(command[0])
-
-	// If not, the executable may be a script within the repo. LookPath will
-	// only find that if we give it a complete path, including the
-	// application directory.
-	if err != nil {
-		executable, err = exec.LookPath(filepath.Join(a.SourceDir, command[0]))
-	}
-
-	if err != nil {
-		return "", err
-	}
-
-	return executable, nil
 }
 
 func readConfig(appName string, sourceDir string) (Config, error) {
@@ -147,6 +160,7 @@ func readConfig(appName string, sourceDir string) (Config, error) {
 		newMode := Mode{
 			Name:         name,
 			StartCommand: mode.StartCommand,
+			StopCommand:  mode.StopCommand,
 			Dependencies: mode.Dependencies,
 		}
 

--- a/domain/app.go
+++ b/domain/app.go
@@ -11,8 +11,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var SourceCodeBaseDir string = viper.GetString("source-code-base-dir")
-
 const configFileName = "devon.conf.yaml"
 
 type App struct {
@@ -159,7 +157,7 @@ func readConfig(appName string, sourceDir string) (Config, error) {
 }
 
 func defaultSourceDir(appName string) string {
-	return filepath.Join(SourceCodeBaseDir, appName)
+	return filepath.Join(viper.GetString("source-code-base-dir"), appName)
 }
 
 func isDirectory(path string) bool {

--- a/domain/app.go
+++ b/domain/app.go
@@ -28,7 +28,7 @@ type Config struct {
 
 type Mode struct {
 	Name         string
-	Command      []string
+	StartCommand []string `yaml:"start-command"`
 	Dependencies map[string]string
 }
 
@@ -71,7 +71,7 @@ func (a *App) Start() error {
 
 	cmd := exec.Cmd{
 		Path:   executable,
-		Args:   a.Mode.Command,
+		Args:   a.Mode.StartCommand,
 		Dir:    a.SourceDir,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
@@ -82,7 +82,7 @@ func (a *App) Start() error {
 
 	if viper.IsSet("verbose") {
 		fmt.Printf("Working directory: %s\n", cmd.Dir)
-		fmt.Printf("Command: %v\n", cmd.Args)
+		fmt.Printf("StartCommand: %v\n", cmd.Args)
 		fmt.Println()
 	}
 
@@ -96,7 +96,7 @@ func (a *App) Start() error {
 }
 
 func (a *App) executable() (string, error) {
-	command := a.Mode.Command
+	command := a.Mode.StartCommand
 
 	// In the case of tools like `make`, the executable will be on the PATH
 	// and LookPath will find it.
@@ -148,7 +148,7 @@ func readConfig(appName string, sourceDir string) (Config, error) {
 	for name, mode := range config.Modes {
 		newMode := Mode{
 			Name:         name,
-			Command:      mode.Command,
+			StartCommand: mode.StartCommand,
 			Dependencies: mode.Dependencies,
 		}
 

--- a/domain/app_test.go
+++ b/domain/app_test.go
@@ -3,12 +3,14 @@ package domain
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 func TestNewApp(t *testing.T) {
 	// Looks for a configuration file in the source code base directory
 	//
-	SourceCodeBaseDir = "./test-fixtures/src"
+	viper.Set("source-code-base-dir", "./test-fixtures/src")
 
 	expectedSourceDir := filepath.Join("test-fixtures", "src", "foo")
 

--- a/domain/test-fixtures/src/foo/devon.conf.yaml
+++ b/domain/test-fixtures/src/foo/devon.conf.yaml
@@ -1,5 +1,5 @@
 modes:
   development:
-    command: ["bar"]
+    start-command: ["bar"]
   unguessable:
-    command: ["baz"]
+    start-command: ["baz"]

--- a/example.yaml
+++ b/example.yaml
@@ -25,13 +25,13 @@ dependencies: &default_dependencies
 #
 modes:
   development:
-    command: ["bash", "-c", "sleep 5; echo Starting devon!"]
+    start-command: ["bash", "-c", "sleep 5; echo Starting devon!"]
     dependencies: *default_dependencies
   dependency:
-    command: ["./dev/up.sh"]
+    start-command: ["./dev/up.sh"]
     dependencies: *default_dependencies
   extra-dependencies:
-    command: ["make", "local"]
+    start-command: ["make", "local"]
     # This app takes the default list and extends it.
     dependencies:
       <<: *default_dependencies

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -5,12 +5,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/viper"
+
 	"github.com/redbubble/devon/domain"
 )
 
 func TestAdd(t *testing.T) {
 	workdir, _ := os.Getwd()
-	domain.SourceCodeBaseDir = filepath.Join(workdir, "test-fixtures", "src")
+	viper.Set("source-code-base-dir", filepath.Join(workdir, "test-fixtures", "src"))
 
 	// Adds the given app to the list of apps to be started
 	apps := []domain.App{}

--- a/resolver/test-fixtures/src/first-dep/devon.conf.yaml
+++ b/resolver/test-fixtures/src/first-dep/devon.conf.yaml
@@ -1,3 +1,3 @@
 modes:
   dependency:
-    command: ["make", "local"]
+    start-command: ["make", "local"]

--- a/resolver/test-fixtures/src/kreis/devon.conf.yaml
+++ b/resolver/test-fixtures/src/kreis/devon.conf.yaml
@@ -1,3 +1,3 @@
 modes:
   dependency:
-    command: []
+    start-command: []


### PR DESCRIPTION
If Devon is responsible for starting apps, it makes sense for it to be responsible for stopping them as well.

This PR adds a minimal `stop` command, which stops a single app. Unfortunately, we need the user to tell us what mode the app is running in before we can stop it.

To make this function possible, I made a breaking change to the app configuration format:

* `command` was renamed to `start-command` to avoid ambiguity.
* `stop-command` was added.