### PR TITLE
Change dependencies from a map to a slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ modes:
         mode: dependency
   dependency:
     start-command: ["dev/up.sh"]
+    stop-command: ["dev/down.sh"]
     dependencies:
       - name: some-app
         mode: some-mode

--- a/README.md
+++ b/README.md
@@ -67,16 +67,19 @@ modes:
   development:
     start-command: ["bundle", "exec", "rails", "server"]
     dependencies:
-      # These are key-value pairs, where the key is the name of
-      # the dependency's git repo, and the value is the name of
-      # the mode the dependency should be started in.
-      my-app: dependency
-      your-app: custom-mode
+      # `name` is the name of the dependency's git repo.
+      # `mode` is the name of the mode the dependency should be started in.
+      - name: some-app
+        mode: some-mode
+      - name: redbubble
+        mode: dependency
   dependency:
     start-command: ["dev/up.sh"]
     dependencies:
-      my-app: dependency
-      your-app: dependency
+      - name: some-app
+        mode: some-mode
+      - name: some-other-app
+        mode: maybe-some-other-mode
 ```
 
 

--- a/domain/app.go
+++ b/domain/app.go
@@ -28,7 +28,12 @@ type Mode struct {
 	Name         string
 	StartCommand []string `yaml:"start-command"`
 	StopCommand  []string `yaml:"stop-command"`
-	Dependencies map[string]string
+	Dependencies []Dependency
+}
+
+type Dependency struct {
+	AppName  string `yaml:"name"`
+	ModeName string `yaml:"mode"`
 }
 
 func NewApp(name string, modeName string) (App, error) {

--- a/example.yaml
+++ b/example.yaml
@@ -10,8 +10,10 @@
 # can use as many or as few of these blocks as we need.
 #
 dependencies: &default_dependencies
-  my-app: dependency
-  your-app: dependency
+  - name: some-app
+    mode: some-mode
+  - name: redbubble
+    mode: dependency
 
 # The different modes in which your app can run (on a dev or test machine).
 #

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -59,8 +59,8 @@ func add(apps []domain.App, app domain.App, depChain []string) ([]domain.App, er
 	startingApps = append(apps, app)
 
 	// Recursively add this app's dependencies
-	for dep_name, dep_mode := range app.Mode.Dependencies {
-		dep, err := domain.NewApp(dep_name, dep_mode)
+	for _, dependency := range app.Mode.Dependencies {
+		dep, err := domain.NewApp(dependency.AppName, dependency.ModeName)
 
 		if err != nil {
 			fmt.Printf("WARNING: %v\n", err)

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -21,7 +21,7 @@ func TestAdd(t *testing.T) {
 		SourceDir: "",
 		Config:    domain.Config{},
 		Mode: domain.Mode{
-			Dependencies: make(map[string]string),
+			Dependencies: make([]domain.Dependency, 0, 1),
 		},
 	}
 
@@ -44,8 +44,12 @@ func TestAdd(t *testing.T) {
 	}
 
 	// Adds the given app's dependencies to the list of apps to be started
-	dependencies := make(map[string]string)
-	dependencies["first-dep"] = "dependency"
+	dependencies := []domain.Dependency{
+		domain.Dependency{
+			AppName:  "first-dep",
+			ModeName: "dependency",
+		},
+	}
 
 	appWithDependencies := domain.App{
 		Name:      "testfenster",
@@ -74,8 +78,12 @@ func TestAdd(t *testing.T) {
 	}
 
 	// Detects circular dependencies and returns an error
-	dependencies = make(map[string]string)
-	dependencies["kreis"] = "dependency"
+	dependencies = []domain.Dependency{
+		domain.Dependency{
+			AppName:  "kreis",
+			ModeName: "dependency",
+		},
+	}
 
 	appWithCircularDependency := domain.App{
 		Name:      "kreis",


### PR DESCRIPTION
Couple of reasons for this:

* User testing suggested that the map format wasn't as clear as I hoped. Having named fields should help.
* Having a distinct type for dependencies allows us to do fun things with them later.