### PR TITLE
Allow modes to set the working directory for their commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ To start an app with Devon, you will need a config file called `devon.conf.yaml`
 modes:
   development:
     start-command: ["bundle", "exec", "rails", "server"]
+    # `working-dir` is the directory where `start-command` and `stop-command`
+    # should be executed. Specify it relative to the repository root.
+    # Defaults to the repository root if unspecified.
+    working-dir: app
     dependencies:
       # `name` is the name of the dependency's git repo.
       # `mode` is the name of the mode the dependency should be started in.

--- a/domain/app_test.go
+++ b/domain/app_test.go
@@ -51,4 +51,27 @@ func TestNewApp(t *testing.T) {
 		}
 	}
 
+	// Each Mode has the correct working directory (defaulting to the App's SourceDir if unset)
+	expectedWorkingDirs := map[string]string{
+		"development": filepath.Join("test-fixtures", "src", "foo"),
+		"unguessable": filepath.Join("test-fixtures", "src", "foo", "fergus"),
+	}
+
+	a, err = NewApp("foo", "development")
+
+	if err != nil {
+		t.Errorf("NewApp returned an unexpected error: %v\n", err)
+	}
+
+	if len(a.Config.Modes) != len(expectedWorkingDirs) {
+		t.Errorf("Expected %d modes, got %d.", len(expectedWorkingDirs), len(a.Config.Modes))
+	}
+
+	for modeName, expectedDir := range expectedWorkingDirs {
+		actualDir := a.Config.Modes[modeName].WorkingDir
+
+		if expectedDir != actualDir {
+			t.Errorf("Expected working dir for '%s' mode to be '%s', but it was '%s'.", modeName, expectedDir, actualDir)
+		}
+	}
 }

--- a/domain/test-fixtures/src/foo/devon.conf.yaml
+++ b/domain/test-fixtures/src/foo/devon.conf.yaml
@@ -3,3 +3,4 @@ modes:
     start-command: ["bar"]
   unguessable:
     start-command: ["baz"]
+    working-dir: "fergus"

--- a/example.yaml
+++ b/example.yaml
@@ -28,6 +28,7 @@ dependencies: &default_dependencies
 modes:
   development:
     start-command: ["bash", "-c", "sleep 5; echo Starting devon!"]
+    working-dir: .
     dependencies: *default_dependencies
   dependency:
     start-command: ["./dev/up.sh"]


### PR DESCRIPTION
Many apps have their source code in a subdirectory of the Git repo, and their `development` mode commands need to run in that working directory.

It's possible to make this work with something like `bash -c "cd app; rails server"`, but that's not exactly obvious, and I'd rather support it directly.

The optional `working-dir` setting allows a Mode to specify a working directory, relative to the repo root. By default, it's set to the repo root.

I thought about preventing the use of `..` in `working-dir`, but then I realised that `start-command` can be literally anything including fully qualified executable paths or arbitrary code in any interpreted language, and a restriction on the working directory wouldn't hinder anyone who wanted to exploit that.

So, yeah. I don't _recommend_ setting the working directory outside the repo, but forbidding it is probably more of a hindrance than a help.

Example:

```
modes:
  development:
    start-command: ["bundle", "exec", "rails", "server"]
    working-dir: app
```

does something equivalent to:

```
$ cd app
$ bundle exec rails server
```