### PR TITLE
Allow start/stop command to read env variables

### DIFF
--- a/domain/app_test.go
+++ b/domain/app_test.go
@@ -74,4 +74,14 @@ func TestNewApp(t *testing.T) {
 			t.Errorf("Expected working dir for '%s' mode to be '%s', but it was '%s'.", modeName, expectedDir, actualDir)
 		}
 	}
+
+	// Modes' environment variables are read correctly
+
+	envVars := EnvVars{EnvVar{Name: "FOO", Value: "bar"}}
+	if expected, actual := envVars[0].Name, a.Mode.Env[0].Name; expected != actual {
+		t.Errorf("Expected env var Name to be %s, got %s", expected, actual)
+	}
+	if expected, actual := envVars[0].Value, a.Mode.Env[0].Value; expected != actual {
+		t.Errorf("Expected env var Value to be %s, got %s", expected, actual)
+	}
 }

--- a/domain/test-fixtures/src/foo/devon.conf.yaml
+++ b/domain/test-fixtures/src/foo/devon.conf.yaml
@@ -1,6 +1,9 @@
 modes:
   development:
     start-command: ["bar"]
+    env:
+      - name: FOO
+        value: bar
   unguessable:
     start-command: ["baz"]
     working-dir: "fergus"

--- a/example.yaml
+++ b/example.yaml
@@ -27,8 +27,11 @@ dependencies: &default_dependencies
 #
 modes:
   development:
-    start-command: ["bash", "-c", "sleep 5; echo Starting devon!"]
+    start-command: ["bash", "-c", "sleep 5; echo Starting devon with FOO=${FOO}!"]
     working-dir: .
+    env:
+      - name: FOO
+        value: bar
     dependencies: *default_dependencies
   dependency:
     start-command: ["./dev/up.sh"]


### PR DESCRIPTION
Allow users to include `env` variables to an application configuration.
